### PR TITLE
Add 'Content-Type' header in IntoResponse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ tokio = { version = "1.29.1", features = ["full"] }
 
 [dev-dependencies]
 axum-test-helpers = "0.7"
+# required for axum-test-helpers to compile
+tower = { version = "0.4.13", features = ["make"] }
+futures-util = "0.3"


### PR DESCRIPTION
Adds the appropriate 'Content-Type' header with value 'application/postcard' when generating a response in `IntoResponse`.

This makes sense as this crate already expects requests to include the Content-Type header, so it should also include it in its responses. This is also consistent with [what axum's Json type does](https://docs.rs/axum/latest/src/axum/json.rs.html#181-209).
The documentation previously stated that the 'application/json' Content-Type was added to the response which was not the case. This is now updated.

I don't know if this crate is still being maintained, but it would be great to see this change on crates.io :)